### PR TITLE
Send confirmation email on successful registration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@logtail/node": "^0.1.14",
         "@logtail/winston": "^0.1.14",
         "@prisma/client": "^4.8.0",
+        "@sendgrid/mail": "^7.7.0",
         "bcryptjs": "^2.4.3",
         "dotenv": "^16.0.3",
         "express": "^4.18.2",
@@ -1324,6 +1325,41 @@
       "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-4.8.0-61.d6e67a83f971b175a593ccc12e15c4a757f93ffe.tgz",
       "integrity": "sha512-MHSOSexomRMom8QN4t7bu87wPPD+pa+hW9+71JnVcF3DqyyO/ycCLhRL1we3EojRpZxKvuyGho2REQsMCvxcJw=="
     },
+    "node_modules/@sendgrid/client": {
+      "version": "7.7.0",
+      "resolved": "https://registry.npmjs.org/@sendgrid/client/-/client-7.7.0.tgz",
+      "integrity": "sha512-SxH+y8jeAQSnDavrTD0uGDXYIIkFylCo+eDofVmZLQ0f862nnqbC3Vd1ej6b7Le7lboyzQF6F7Fodv02rYspuA==",
+      "dependencies": {
+        "@sendgrid/helpers": "^7.7.0",
+        "axios": "^0.26.0"
+      },
+      "engines": {
+        "node": "6.* || 8.* || >=10.*"
+      }
+    },
+    "node_modules/@sendgrid/helpers": {
+      "version": "7.7.0",
+      "resolved": "https://registry.npmjs.org/@sendgrid/helpers/-/helpers-7.7.0.tgz",
+      "integrity": "sha512-3AsAxfN3GDBcXoZ/y1mzAAbKzTtUZ5+ZrHOmWQ279AuaFXUNCh9bPnRpN504bgveTqoW+11IzPg3I0WVgDINpw==",
+      "dependencies": {
+        "deepmerge": "^4.2.2"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/@sendgrid/mail": {
+      "version": "7.7.0",
+      "resolved": "https://registry.npmjs.org/@sendgrid/mail/-/mail-7.7.0.tgz",
+      "integrity": "sha512-5+nApPE9wINBvHSUxwOxkkQqM/IAAaBYoP9hw7WwgDNQPxraruVqHizeTitVtKGiqWCKm2mnjh4XGN3fvFLqaw==",
+      "dependencies": {
+        "@sendgrid/client": "^7.7.0",
+        "@sendgrid/helpers": "^7.7.0"
+      },
+      "engines": {
+        "node": "6.* || 8.* || >=10.*"
+      }
+    },
     "node_modules/@sideway/address": {
       "version": "4.1.4",
       "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.4.tgz",
@@ -2219,6 +2255,14 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
       "dev": true
     },
+    "node_modules/axios": {
+      "version": "0.26.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
+      "integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
+      "dependencies": {
+        "follow-redirects": "^1.14.8"
+      }
+    },
     "node_modules/babel-jest": {
       "version": "29.3.1",
       "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-29.3.1.tgz",
@@ -2805,7 +2849,6 @@
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
       "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3504,6 +3547,25 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fn.name/-/fn.name-1.1.0.tgz",
       "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw=="
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
+      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
     },
     "node_modules/form-data": {
       "version": "4.0.0",
@@ -7774,6 +7836,32 @@
       "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-4.8.0-61.d6e67a83f971b175a593ccc12e15c4a757f93ffe.tgz",
       "integrity": "sha512-MHSOSexomRMom8QN4t7bu87wPPD+pa+hW9+71JnVcF3DqyyO/ycCLhRL1we3EojRpZxKvuyGho2REQsMCvxcJw=="
     },
+    "@sendgrid/client": {
+      "version": "7.7.0",
+      "resolved": "https://registry.npmjs.org/@sendgrid/client/-/client-7.7.0.tgz",
+      "integrity": "sha512-SxH+y8jeAQSnDavrTD0uGDXYIIkFylCo+eDofVmZLQ0f862nnqbC3Vd1ej6b7Le7lboyzQF6F7Fodv02rYspuA==",
+      "requires": {
+        "@sendgrid/helpers": "^7.7.0",
+        "axios": "^0.26.0"
+      }
+    },
+    "@sendgrid/helpers": {
+      "version": "7.7.0",
+      "resolved": "https://registry.npmjs.org/@sendgrid/helpers/-/helpers-7.7.0.tgz",
+      "integrity": "sha512-3AsAxfN3GDBcXoZ/y1mzAAbKzTtUZ5+ZrHOmWQ279AuaFXUNCh9bPnRpN504bgveTqoW+11IzPg3I0WVgDINpw==",
+      "requires": {
+        "deepmerge": "^4.2.2"
+      }
+    },
+    "@sendgrid/mail": {
+      "version": "7.7.0",
+      "resolved": "https://registry.npmjs.org/@sendgrid/mail/-/mail-7.7.0.tgz",
+      "integrity": "sha512-5+nApPE9wINBvHSUxwOxkkQqM/IAAaBYoP9hw7WwgDNQPxraruVqHizeTitVtKGiqWCKm2mnjh4XGN3fvFLqaw==",
+      "requires": {
+        "@sendgrid/client": "^7.7.0",
+        "@sendgrid/helpers": "^7.7.0"
+      }
+    },
     "@sideway/address": {
       "version": "4.1.4",
       "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.4.tgz",
@@ -8503,6 +8591,14 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
       "dev": true
     },
+    "axios": {
+      "version": "0.26.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
+      "integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
+      "requires": {
+        "follow-redirects": "^1.14.8"
+      }
+    },
     "babel-jest": {
       "version": "29.3.1",
       "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-29.3.1.tgz",
@@ -8960,8 +9056,7 @@
     "deepmerge": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
-      "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==",
-      "dev": true
+      "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg=="
     },
     "delayed-stream": {
       "version": "1.0.0",
@@ -9514,6 +9609,11 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fn.name/-/fn.name-1.1.0.tgz",
       "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw=="
+    },
+    "follow-redirects": {
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
+      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA=="
     },
     "form-data": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "@logtail/node": "^0.1.14",
     "@logtail/winston": "^0.1.14",
     "@prisma/client": "^4.8.0",
+    "@sendgrid/mail": "^7.7.0",
     "bcryptjs": "^2.4.3",
     "dotenv": "^16.0.3",
     "express": "^4.18.2",

--- a/src/routes/user.route.ts
+++ b/src/routes/user.route.ts
@@ -2,6 +2,7 @@ import { Request, Response, Router } from "express";
 
 import { User, userSchema } from "../models/user.model";
 
+import { sendConfirmationEmail } from "../services/email.service";
 import {
   createUser,
   generateAccessToken,
@@ -36,6 +37,7 @@ router.post("/register", async (req: Request, res: Response) => {
     const user = await createUser(req.body);
 
     logger.info("User created: " + user.id);
+    sendConfirmationEmail(user.email);
     res.status(STATUS_CODES.CREATED).json({
       status: "success",
       message: "User created successfully",

--- a/src/services/email.service.ts
+++ b/src/services/email.service.ts
@@ -1,0 +1,26 @@
+import logger from "../utils/logger";
+
+require("dotenv").config();
+
+const sgMail = require("@sendgrid/mail");
+
+sgMail.setApiKey(process.env.SENDGRID_API_KEY);
+
+export function sendConfirmationEmail(email: string) {
+  const message = {
+    to: email,
+    from: process.env.SENDGRID_FROM_ADDRESS,
+    subject: "Kid Toys account created",
+    text: "Thank you for creating an account at Kid Toys.",
+  };
+
+  sgMail
+    .send(message)
+    .then((response: any) => {
+      logger.info(response[0].statusCode);
+      logger.info(response[0].headers);
+    })
+    .catch((error: any) => {
+      logger.error(error);
+    });
+}

--- a/src/services/email.service.ts
+++ b/src/services/email.service.ts
@@ -16,9 +16,8 @@ export function sendConfirmationEmail(email: string) {
 
   sgMail
     .send(message)
-    .then((response: any) => {
-      logger.info(response[0].statusCode);
-      logger.info(response[0].headers);
+    .then(() => {
+      logger.info("Email sent successfully");
     })
     .catch((error: any) => {
       logger.error(error);

--- a/src/services/email.service.ts
+++ b/src/services/email.service.ts
@@ -6,7 +6,7 @@ const sgMail = require("@sendgrid/mail");
 
 sgMail.setApiKey(process.env.SENDGRID_API_KEY);
 
-export function sendConfirmationEmail(email: string) {
+export function sendConfirmationEmail(email: string): void {
   const message = {
     to: email,
     from: process.env.SENDGRID_FROM_ADDRESS,

--- a/tests/userRegistration.test.ts
+++ b/tests/userRegistration.test.ts
@@ -77,7 +77,6 @@ describe("User Registration", () => {
 
       await sendRegisterPostRequest(data);
 
-      expect(sendConfirmationEmail).toHaveBeenCalled();
       expect(sendConfirmationEmail).toHaveBeenCalledWith(email);
     });
   });

--- a/tests/userRegistration.test.ts
+++ b/tests/userRegistration.test.ts
@@ -1,10 +1,19 @@
 import request from "supertest";
 
+import { Role } from "../src/models/user.model";
+
+import { sendConfirmationEmail } from "../src/services/email.service";
+
+import { STATUS_CODES } from "../src/utils/constants";
+
+import { PrismaUser, prismaMock } from "../singleton";
 import app from "../src/server";
-import {prismaMock, PrismaUser} from "../singleton";
-import {Role} from "../src/models/user.model";
-import {STATUS_CODES} from "../src/utils/constants";
+
 import ResolvedValue = jest.ResolvedValue;
+
+jest.mock("../src/services/email.service", () => ({
+  sendConfirmationEmail: jest.fn(),
+}));
 
 interface RequestData {
   firstName?: string;
@@ -29,8 +38,8 @@ describe("User Registration", () => {
 
   describe("Successful registration", () => {
     it("should create 'user' with only email and password provided", async () => {
-      const data = {email, password};
-      const userToCreate = {email, password} as ResolvedValue<PrismaUser>;
+      const data = { email, password };
+      const userToCreate = { email, password } as ResolvedValue<PrismaUser>;
 
       prismaMock.user.create.mockResolvedValue(userToCreate);
 
@@ -59,11 +68,23 @@ describe("User Registration", () => {
 
       await sendRegisterPostRequest(data).expect(STATUS_CODES.CREATED);
     });
+
+    it("should send a confirmation email", async () => {
+      const data = { email, password };
+      const userToCreate = { email, password } as ResolvedValue<PrismaUser>;
+
+      prismaMock.user.create.mockResolvedValue(userToCreate);
+
+      await sendRegisterPostRequest(data);
+
+      expect(sendConfirmationEmail).toHaveBeenCalled();
+      expect(sendConfirmationEmail).toHaveBeenCalledWith(email);
+    });
   });
 
   describe("Unsuccessful registration", () => {
     it("should not be able to register with already taken email", async () => {
-      const data = {email, password};
+      const data = { email, password };
       const mockedExistingUser = {
         id: 123,
         firstName,
@@ -80,17 +101,39 @@ describe("User Registration", () => {
       await sendRegisterPostRequest(data).expect(STATUS_CODES.CONFLICT);
     });
 
+    it("should not send a confirmation email", async () => {
+      const data = { email, password };
+      const mockedExistingUser = {
+        id: 123,
+        firstName,
+        lastName,
+        phoneNumber,
+        address,
+        email,
+        password,
+        role: Role.admin,
+      } as ResolvedValue<PrismaUser>;
+
+      prismaMock.user.findUnique.mockResolvedValue(mockedExistingUser);
+
+      await sendRegisterPostRequest(data);
+
+      expect(sendConfirmationEmail).not.toHaveBeenCalled();
+    });
+
     it("should not be able to register user without email", async () => {
-      await sendRegisterPostRequest({password}).expect(STATUS_CODES.BAD_REQUEST)
-        .expect(body => {
+      await sendRegisterPostRequest({ password })
+        .expect(STATUS_CODES.BAD_REQUEST)
+        .expect((body) => {
           const text = JSON.parse(body.text);
           expect(text.message).toBe('"email" is required');
         });
     });
 
     it("should not be able to register user without password", async () => {
-      await sendRegisterPostRequest({email}).expect(STATUS_CODES.BAD_REQUEST)
-        .expect(body => {
+      await sendRegisterPostRequest({ email })
+        .expect(STATUS_CODES.BAD_REQUEST)
+        .expect((body) => {
           const text = JSON.parse(body.text);
           expect(text.message).toBe('"password" is required');
         });
@@ -100,83 +143,113 @@ describe("User Registration", () => {
       await sendRegisterPostRequest({
         firstName: "A really really really really really long name",
         email,
-        password
-      }).expect(STATUS_CODES.BAD_REQUEST).expect(body => {
-        const text = JSON.parse(body.text);
-        expect(text.message).toBe('"firstName" length must be less than or equal to 45 characters long');
-      });
+        password,
+      })
+        .expect(STATUS_CODES.BAD_REQUEST)
+        .expect((body) => {
+          const text = JSON.parse(body.text);
+          expect(text.message).toBe(
+            '"firstName" length must be less than or equal to 45 characters long'
+          );
+        });
     });
 
     it("should not be able to register with too long lastName", async () => {
       await sendRegisterPostRequest({
         lastName: "A really really really really really long name",
         email,
-        password
-      }).expect(STATUS_CODES.BAD_REQUEST).expect(body => {
-        const text = JSON.parse(body.text);
-        expect(text.message).toBe('"lastName" length must be less than or equal to 45 characters long');
-      });
+        password,
+      })
+        .expect(STATUS_CODES.BAD_REQUEST)
+        .expect((body) => {
+          const text = JSON.parse(body.text);
+          expect(text.message).toBe(
+            '"lastName" length must be less than or equal to 45 characters long'
+          );
+        });
     });
 
     it("should not be able to register with invalid phone number", async () => {
       await sendRegisterPostRequest({
         phoneNumber: "12345aa",
         email,
-        password
-      }).expect(STATUS_CODES.BAD_REQUEST).expect(body => {
-        const text = JSON.parse(body.text);
-        expect(text.message).toBe('"phoneNumber" must be a number');
-      });
+        password,
+      })
+        .expect(STATUS_CODES.BAD_REQUEST)
+        .expect((body) => {
+          const text = JSON.parse(body.text);
+          expect(text.message).toBe('"phoneNumber" must be a number');
+        });
     });
 
     it("should not be able to register with too short password", async () => {
       await sendRegisterPostRequest({
         email: "test@test.com",
         password: "testTEST12!",
-      }).expect(STATUS_CODES.BAD_REQUEST).expect(body => {
-        const text = JSON.parse(body.text);
-        expect(text.message).toBe('"password" with value \"testTEST12!\" fails to match the required pattern: /^(?=.*[A-Z])(?=.*[a-z])(?=.*\\d)(?=.*[@$!%*#?&])[A-Za-z\\d@$!%*#?&]{12,}$/');
-      });
+      })
+        .expect(STATUS_CODES.BAD_REQUEST)
+        .expect((body) => {
+          const text = JSON.parse(body.text);
+          expect(text.message).toBe(
+            '"password" with value "testTEST12!" fails to match the required pattern: /^(?=.*[A-Z])(?=.*[a-z])(?=.*\\d)(?=.*[@$!%*#?&])[A-Za-z\\d@$!%*#?&]{12,}$/'
+          );
+        });
     });
 
     it("should not be able to register with invalid password (no lowercase letters)", async () => {
       await sendRegisterPostRequest({
         email: "test@test.com",
         password: "TESTPASS123!",
-      }).expect(STATUS_CODES.BAD_REQUEST).expect(body => {
-        const text = JSON.parse(body.text);
-        expect(text.message).toBe('"password" with value \"TESTPASS123!\" fails to match the required pattern: /^(?=.*[A-Z])(?=.*[a-z])(?=.*\\d)(?=.*[@$!%*#?&])[A-Za-z\\d@$!%*#?&]{12,}$/');
-      });
+      })
+        .expect(STATUS_CODES.BAD_REQUEST)
+        .expect((body) => {
+          const text = JSON.parse(body.text);
+          expect(text.message).toBe(
+            '"password" with value "TESTPASS123!" fails to match the required pattern: /^(?=.*[A-Z])(?=.*[a-z])(?=.*\\d)(?=.*[@$!%*#?&])[A-Za-z\\d@$!%*#?&]{12,}$/'
+          );
+        });
     });
 
     it("should not be able to register with invalid password (no uppercase letters)", async () => {
       await sendRegisterPostRequest({
         email: "test@test.com",
         password: "testpass123!",
-      }).expect(STATUS_CODES.BAD_REQUEST).expect(body => {
-        const text = JSON.parse(body.text);
-        expect(text.message).toBe('"password" with value \"testpass123!\" fails to match the required pattern: /^(?=.*[A-Z])(?=.*[a-z])(?=.*\\d)(?=.*[@$!%*#?&])[A-Za-z\\d@$!%*#?&]{12,}$/');
-      });
+      })
+        .expect(STATUS_CODES.BAD_REQUEST)
+        .expect((body) => {
+          const text = JSON.parse(body.text);
+          expect(text.message).toBe(
+            '"password" with value "testpass123!" fails to match the required pattern: /^(?=.*[A-Z])(?=.*[a-z])(?=.*\\d)(?=.*[@$!%*#?&])[A-Za-z\\d@$!%*#?&]{12,}$/'
+          );
+        });
     });
 
     it("should not be able to register with invalid password (no numbers)", async () => {
       await sendRegisterPostRequest({
         email: "test@test.com",
         password: "testTESTtest!",
-      }).expect(STATUS_CODES.BAD_REQUEST).expect(body => {
-        const text = JSON.parse(body.text);
-        expect(text.message).toBe('"password" with value \"testTESTtest!\" fails to match the required pattern: /^(?=.*[A-Z])(?=.*[a-z])(?=.*\\d)(?=.*[@$!%*#?&])[A-Za-z\\d@$!%*#?&]{12,}$/');
-      });
+      })
+        .expect(STATUS_CODES.BAD_REQUEST)
+        .expect((body) => {
+          const text = JSON.parse(body.text);
+          expect(text.message).toBe(
+            '"password" with value "testTESTtest!" fails to match the required pattern: /^(?=.*[A-Z])(?=.*[a-z])(?=.*\\d)(?=.*[@$!%*#?&])[A-Za-z\\d@$!%*#?&]{12,}$/'
+          );
+        });
     });
 
     it("should not be able to register with invalid password (no symbols)", async () => {
       await sendRegisterPostRequest({
         email: "test@test.com",
         password: "testTEST12345",
-      }).expect(STATUS_CODES.BAD_REQUEST).expect(body => {
-        const text = JSON.parse(body.text);
-        expect(text.message).toBe('"password" with value \"testTEST12345\" fails to match the required pattern: /^(?=.*[A-Z])(?=.*[a-z])(?=.*\\d)(?=.*[@$!%*#?&])[A-Za-z\\d@$!%*#?&]{12,}$/');
-      });
+      })
+        .expect(STATUS_CODES.BAD_REQUEST)
+        .expect((body) => {
+          const text = JSON.parse(body.text);
+          expect(text.message).toBe(
+            '"password" with value "testTEST12345" fails to match the required pattern: /^(?=.*[A-Z])(?=.*[a-z])(?=.*\\d)(?=.*[@$!%*#?&])[A-Za-z\\d@$!%*#?&]{12,}$/'
+          );
+        });
     });
   });
 });


### PR DESCRIPTION
We have narrowed the email provider choices down to MailChimp and SendGrid. I used SendGrid, because it is more geared towards developers, instead of to marketing people.

I've created a function `sendConfirmationEmail` that accepts an email address. The function is called whenever a user is successfully registered. I manually tested the `/api/register` endpoint to see if the emails are sent on successful registration. They are.

I've created two tests. One for successful registration, where I test if the function `sendConfirmationEmail` is called and if it's been called with correct argument. For unsuccessful registration, I tested if this function has not been called.